### PR TITLE
Add deploy files to create a new TLJH instance with the gallery

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,25 @@
 # voila-gallery.org-deploy
 
 Configuration and deployment files for [voila-gallery.org](https://voila-gallery.org)
+
+At the moment the gallery is deployed as a plugin for [The Littlest JupyterHub](https://tljh.jupyter.org), running on a single [OVH](https://ovh.com) instance.
+
+## Initial setup
+
+Retrieve the `openrc.sh` file for the `voila-gallery-deploy` user.
+
+```bash
+source openrc.sh
+cd ovh/
+./setup.sh
+```
+
+## Deploy a new version of the gallery
+
+The tag should correspond to a git hash for the [gallery repo](https://github.com/voila-gallery/gallery).
+
+```bash
+source openrc.sh
+cd ovh/
+python deploy.py --tag c0ab38a
+```

--- a/ovh/deploy.py
+++ b/ovh/deploy.py
@@ -1,0 +1,43 @@
+import argparse
+import uuid
+
+import openstack
+
+# FIXME: change prefix to voila-gallery- or make this configurable
+GALLERY_PREFIX = "voici-gallery-"
+IMAGE = "Ubuntu 19.04"
+# FIXME: switch to b2-30
+FLAVOR = "b2-7"
+
+argparser = argparse.ArgumentParser()
+argparser.add_argument(
+    '--tag',
+    help='Suffix to add to the instance name (git commit hash)',
+    required=True,
+)
+args = argparser.parse_args()
+
+cloud = openstack.connect()
+
+servers = cloud.list_servers()
+galleries = [server for server in servers if server.name.startswith(GALLERY_PREFIX)]
+
+# Create the new instance
+with open('./user-data.sh') as f:
+    user_data = f.read()
+
+instance_suffix = uuid.uuid4().hex[:6]
+cloud.create_server(
+    image=IMAGE,
+    flavor=FLAVOR,
+    userdata=user_data.format(ref=args.tag),
+    name=f"{GALLERY_PREFIX}{args.tag}-{instance_suffix}",
+)
+
+# FIXME: poll /api until ready
+
+# FIXME: add to an existing floating ip
+
+# Shutdown old servers
+for gallery in galleries:
+    cloud.delete_server(gallery.name, wait=True)

--- a/ovh/deploy.py
+++ b/ovh/deploy.py
@@ -88,15 +88,9 @@ def main():
 
     galleries = list_servers(cloud)
 
-    # setup a new voila-gallery instance
     server = create_server(cloud, args.tag)
-
-    # wait for the new server to be ready
     poll_server(cloud, server.id)
-
     # FIXME: add to an existing floating ip
-
-    # Shutdown old servers
     stop_servers(cloud, galleries)
 
 

--- a/ovh/deploy.py
+++ b/ovh/deploy.py
@@ -12,8 +12,8 @@ IMAGE = "Ubuntu 19.04"
 # FIXME: switch to b2-30
 FLAVOR = "b2-7"
 USER_DATA_FILE = "./user-data.sh"
-POLL_TIMEOUT = 20 * 60
 POLL_INTERVAL = 30
+POLL_MAX_TIMEOUT = 20 * 60
 
 logger = logging.getLogger(__name__)
 
@@ -24,23 +24,42 @@ def list_servers(cloud):
     return [server for server in servers if server.name.startswith(GALLERY_PREFIX)]
 
 
-def poll_server(cloud, server_id):
-    tries = POLL_TIMEOUT // POLL_INTERVAL
-    for i in range(tries):
-        try:
-            logger.info("Check server is ACTIVE: %s", server_id)
-            server = cloud.get_server_by_id(server_id)
-            addr_ipv4 = next(
-                (addr for addr in server.addresses["Ext-Net"] if addr["version"] == 4)
-            )
-            addr = addr_ipv4["addr"]
-            url = f"http://{addr}/api"
-            logger.info("Poll %s", url)
-            requests.get(url, timeout=10, verify=False)
-        except Exception as e:
-            time.sleep(POLL_INTERVAL)
-        else:
-            break
+def retry(interval=POLL_INTERVAL, max_timeout=POLL_MAX_TIMEOUT):
+    def wrap(func):
+        def wrapped(*args, **kwargs):
+            tries = max_timeout // interval
+            for _ in range(tries):
+                try:
+                    return func(*args, **kwargs)
+                except Exception as e:
+                    time.sleep(interval)
+                else:
+                    break
+
+        return wrapped
+
+    return wrap
+
+
+@retry(interval=10, max_timeout=300)
+def poll_server_active(cloud, server_id):
+    logger.info("Check server is ACTIVE: %s", server_id)
+    server = cloud.get_server_by_id(server_id)
+    if server.status != "ACTIVE":
+        raise Exception("Not ACTIVE")
+    logger.info("Server %s is ACTIVE", server_id)
+
+
+@retry()
+def poll_server_ready(cloud, server_id):
+    server = cloud.get_server_by_id(server_id)
+    addr_ipv4 = next(
+        (addr for addr in server.addresses["Ext-Net"] if addr["version"] == 4)
+    )
+    addr = addr_ipv4["addr"]
+    url = f"http://{addr}/api"
+    logger.info("Poll %s", url)
+    requests.get(url, timeout=10, verify=False)
 
 
 def create_server(cloud, tag):
@@ -89,7 +108,8 @@ def main():
     galleries = list_servers(cloud)
 
     server = create_server(cloud, args.tag)
-    poll_server(cloud, server.id)
+    poll_server_active(cloud, server.id)
+    poll_server_ready(cloud, server.id)
     # FIXME: add to an existing floating ip
     stop_servers(cloud, galleries)
 

--- a/ovh/deploy.py
+++ b/ovh/deploy.py
@@ -8,36 +8,51 @@ GALLERY_PREFIX = "voici-gallery-"
 IMAGE = "Ubuntu 19.04"
 # FIXME: switch to b2-30
 FLAVOR = "b2-7"
+USER_DATA_FILE = "./user-data.sh"
 
-argparser = argparse.ArgumentParser()
-argparser.add_argument(
-    '--tag',
-    help='Suffix to add to the instance name (git commit hash)',
-    required=True,
-)
-args = argparser.parse_args()
 
-cloud = openstack.connect()
+def create_server(cloud, tag):
+    with open(USER_DATA_FILE) as f:
+        user_data = f.read()
 
-servers = cloud.list_servers()
-galleries = [server for server in servers if server.name.startswith(GALLERY_PREFIX)]
+    instance_suffix = uuid.uuid4().hex[:6]
+    cloud.create_server(
+        image=IMAGE,
+        flavor=FLAVOR,
+        userdata=user_data.format(ref=tag),
+        name=f"{GALLERY_PREFIX}{tag}-{instance_suffix}",
+    )
 
-# Create the new instance
-with open('./user-data.sh') as f:
-    user_data = f.read()
+    # FIXME: poll /api until ready
 
-instance_suffix = uuid.uuid4().hex[:6]
-cloud.create_server(
-    image=IMAGE,
-    flavor=FLAVOR,
-    userdata=user_data.format(ref=args.tag),
-    name=f"{GALLERY_PREFIX}{args.tag}-{instance_suffix}",
-)
+    # FIXME: add to an existing floating ip
 
-# FIXME: poll /api until ready
 
-# FIXME: add to an existing floating ip
+def stop_servers(cloud, servers):
+    for server in servers:
+        cloud.delete_server(server.name, wait=True)
 
-# Shutdown old servers
-for gallery in galleries:
-    cloud.delete_server(gallery.name, wait=True)
+
+def main():
+    argparser = argparse.ArgumentParser()
+    argparser.add_argument(
+        '--tag',
+        help='Suffix to add to the instance name (git commit hash)',
+        required=True,
+    )
+    args = argparser.parse_args()
+
+    cloud = openstack.connect()
+
+    servers = cloud.list_servers()
+    galleries = [server for server in servers if server.name.startswith(GALLERY_PREFIX)]
+
+    # setup a new voila-gallery instance
+    create_server(cloud, args.tag)
+
+    # Shutdown old servers
+    stop_servers(cloud, galleries)
+
+
+if __name__ == "__main__":
+    main()

--- a/ovh/deploy.py
+++ b/ovh/deploy.py
@@ -1,7 +1,9 @@
 import argparse
+import time
 import uuid
 
 import openstack
+import requests
 
 # FIXME: change prefix to voila-gallery- or make this configurable
 GALLERY_PREFIX = "voici-gallery-"
@@ -9,6 +11,26 @@ IMAGE = "Ubuntu 19.04"
 # FIXME: switch to b2-30
 FLAVOR = "b2-7"
 USER_DATA_FILE = "./user-data.sh"
+POLL_TIMEOUT = 20 * 60
+POLL_INTERVAL = 30
+
+
+def poll_server(cloud, server_id):
+    tries = POLL_TIMEOUT // POLL_INTERVAL
+    for i in range(tries):
+        try:
+            server = cloud.get_server_by_id(server_id)
+            addr_ipv4 = next(
+                (addr for addr in server.addresses["Ext-Net"] if addr["version"] == 4)
+            )
+            addr = addr_ipv4["addr"]
+            url = f"http://{addr}/api"
+            requests.get(url, timeout=10, verify=False)
+        except Exception as e:
+            print("sleep", POLL_INTERVAL)
+            time.sleep(POLL_INTERVAL)
+        else:
+            break
 
 
 def create_server(cloud, tag):
@@ -16,14 +38,14 @@ def create_server(cloud, tag):
         user_data = f.read()
 
     instance_suffix = uuid.uuid4().hex[:6]
-    cloud.create_server(
+    server = cloud.create_server(
         image=IMAGE,
         flavor=FLAVOR,
         userdata=user_data.format(ref=tag),
         name=f"{GALLERY_PREFIX}{tag}-{instance_suffix}",
     )
 
-    # FIXME: poll /api until ready
+    poll_server(cloud, server.id)
 
     # FIXME: add to an existing floating ip
 
@@ -36,8 +58,8 @@ def stop_servers(cloud, servers):
 def main():
     argparser = argparse.ArgumentParser()
     argparser.add_argument(
-        '--tag',
-        help='Suffix to add to the instance name (git commit hash)',
+        "--tag",
+        help="Suffix to add to the instance name (git commit hash)",
         required=True,
     )
     args = argparser.parse_args()

--- a/ovh/requirements.txt
+++ b/ovh/requirements.txt
@@ -1,0 +1,1 @@
+python-openstackclient

--- a/ovh/requirements.txt
+++ b/ovh/requirements.txt
@@ -1,1 +1,2 @@
 python-openstackclient
+requests

--- a/ovh/setup.sh
+++ b/ovh/setup.sh
@@ -1,0 +1,1 @@
+# TODO: setup floating IP

--- a/ovh/user-data.sh
+++ b/ovh/user-data.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+curl https://raw.githubusercontent.com/jupyterhub/the-littlest-jupyterhub/master/bootstrap/bootstrap.py \
+ | sudo python3 - \
+   --plugin git+https://github.com/voila-gallery/gallery@{ref}#"egg=tljh-voila-gallery&subdirectory=tljh-voila-gallery"
+
+
+sudo tljh-config set https.enabled true
+sudo tljh-config set https.letsencrypt.email contact@voila-gallery.org
+sudo tljh-config add-item https.letsencrypt.domains voila-gallery.org
+
+sudo tljh-config reload proxy

--- a/ovh/user-data.sh
+++ b/ovh/user-data.sh
@@ -4,7 +4,7 @@ curl https://raw.githubusercontent.com/jupyterhub/the-littlest-jupyterhub/master
    --plugin git+https://github.com/voila-gallery/gallery@{ref}#"egg=tljh-voila-gallery&subdirectory=tljh-voila-gallery"
 
 
-sudo tljh-config set https.enabled true
+sudo tljh-config set https.enabled {https}
 sudo tljh-config set https.letsencrypt.email contact@voila-gallery.org
 sudo tljh-config add-item https.letsencrypt.domains voila-gallery.org
 


### PR DESCRIPTION
This PR adds a few configuration files to deploy a new version of the gallery to OVH without having to click through the UI or manually SSH to the machine.

This takes the current design into account:

- deployed on a single instance
- using TLJH + plugin system

## TODO

- [x] Add `deploy.py` file
- [x] Add logging
- [ ]  Add `dry-run` mode
- [ ] Fix `FIXME`s

Other options to consider would be:

- Terraform: need to share the state in some way
- Ansible: is it worth the effort?
- Make the gallery work on Kubernetes using `KubeSpawner`? Interesting for the long term, but it would also add a bit of complexity: building and pushing the images to a registry, extending the ZTJH helm chart or creating its own... 
